### PR TITLE
Add remote file sync

### DIFF
--- a/remote_kernel/__init__.py
+++ b/remote_kernel/__init__.py
@@ -16,6 +16,7 @@ kernel_name           --
 transport             --transport  ['tcp', 'icp']
 """
 
+import argparse
 from collections import OrderedDict
 import logging
 
@@ -28,10 +29,55 @@ logger.addHandler(hndlr)
 logger.setLevel(logging.INFO)
 hndlr.setLevel(logging.INFO)
 
+
 def get_resource_dir():
   import os
   resource_dir = os.path.join(os.path.dirname(__file__), 'resources')
   return os.path.abspath(resource_dir)
+
+
+def get_parser(connection_file_arg=True):
+  parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
+
+  ssh_group = parser.add_argument_group(title='SSH Connection', description="Arguments specifying the SSH connection "
+                                                                            "to the remote server")
+  ssh_group.add_argument('--target', '-t', metavar='[username@]host[:port]', required=True,
+                         help='Remote server to connect to. Formatted as [username@]host[:port]')
+  ssh_group.add_argument('-J', dest='jump_server', metavar='[username@]host[:port]', default=None, action='append',
+                         help='Optional jump servers to connect through to the host')
+  ssh_group.add_argument('-i', dest='ssh_key', default=None, help='ssh key to use for authentication')
+
+  ipykernel_group = parser.add_argument_group(title='IPyKernel Arguments', description="Arguments to start the "
+                                                                                       "ipykernel on the remote server")
+  ipykernel_group.add_argument('--kernel', '-k', default='python -m ipykernel',
+                               help='Kernel start command, default is "ipykernel"')
+  ipykernel_group.add_argument('--command', '-c', default=None,
+                               help='Additional commands to execute on remote server, prior to '
+                                    'starting the kernel (specified in `--kernel`)')
+  ipykernel_group.add_argument('--name', '-n', default='remote_kernel-%(user)s@%(host)s',
+                               help='Display name of the kernel to install\n'
+                                    'Default: remote_kernel-<user>@<host>')
+  if connection_file_arg:
+    ipykernel_group.add_argument('--file', '-f', help='Connection file to configure the kernel')
+
+  ipykernel_group.add_argument('--no-remote-files', action='store_true',
+                               help='If specified, no remote files are created/removed on the remote host.\n'
+                                    'Connection arguments are passed via commandline.\n'
+                                    'N.B. This is less secure, as these arguments are visible in the processes list!')
+
+  sync_group = parser.add_argument_group(title='Remote file sync options',
+                                         description='Arguments controlling synchronization of remote files')
+  sync_group.add_argument('--synchronize', '-s', action='store_true', help='If specified, synchronizes files')
+  sync_group.add_argument('--no-recursive', '-nr', action='store_false', dest='recursive',
+                          help='If specified, skips synchronizing files in the sub-folders of the sync folder')
+  sync_group.add_argument('--bi-directional', '-bd', action='store_true',
+                          help='If specified, synchronizes from remote to local and from local to remote')
+  sync_group.add_argument('--remote-folder', '-rf', default='remote_kernel_sync',
+                          help='Remote root folder to sync (containing sub-folders for each unique local folder')
+  sync_group.add_argument('--local-folder', '-lf', default='remote_kernel_sync',
+                          help='Name of local sub-folder to synchronize')
+  return parser
+
 
 # argument template for starting up an IPyKernel without supplying a connection file
 # arguments to fill this template are read from the connection file which remains on

--- a/remote_kernel/__init__.py
+++ b/remote_kernel/__init__.py
@@ -51,7 +51,7 @@ def get_parser(connection_file_arg=True):
                                                                                        "ipykernel on the remote server")
   ipykernel_group.add_argument('--kernel', '-k', default='python -m ipykernel',
                                help='Kernel start command, default is "ipykernel"')
-  ipykernel_group.add_argument('--command', '-c', default=None,
+  ipykernel_group.add_argument('--pre-command', '-pc', default=None,
                                help='Additional commands to execute on remote server, prior to '
                                     'starting the kernel (specified in `--kernel`)')
   ipykernel_group.add_argument('--name', '-n', default='remote_kernel-%(user)s@%(host)s',

--- a/remote_kernel/install.py
+++ b/remote_kernel/install.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import logging
 import os
@@ -6,34 +5,17 @@ import shutil
 import sys
 
 from jupyter_core.paths import jupyter_data_dir
-import paramiko
 
-from . import CMD_ARGS, get_resource_dir
+from . import CMD_ARGS, get_parser, get_resource_dir
 from .ssh_client import ParamikoClient
+from .sync import ParamikoSync
 
 
 logger = logging.getLogger('remote_kernel.install')
 
 
 def parse_args(argv=None):
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--target', '-t', metavar='[username@]host[:port]', required=True,
-                      help='Remote server to connect to. Formatted as [username@]host[:port]')
-  parser.add_argument('-J', dest='jump_server', metavar='[username@]host[:port]', default=None, action='append',
-                      help='Optional jump servers to connect through to the host')
-  parser.add_argument('-i', dest='ssh_key', default=None, help='ssh key to use for authentication')
-  parser.add_argument('--kernel', '-k', default='python -m ipykernel',
-                      help='Kernel start command, default is "ipykernel"')
-  parser.add_argument('--command', '-c', default=None,
-                      help='Additional commands to execute on remote server, prior to '
-                           'starting the kernel (specified in `--kernel`)')
-  parser.add_argument('--name', '-n', default='remote_kernel-%(user)s@%(host)s',
-                      help='Display name of the kernel to install\n'
-                           'Default: remote_kernel-<user>@<host>')
-  parser.add_argument('--no-remote-files', action='store_true',
-                      help='If specified, no remote files are created/removed on the remote host.\n'
-                           'Connection arguments are passed via commandline.\n'
-                           'N.B. This is less secure, as these arguments are visible in the processes list!')
+  parser = get_parser(connection_file_arg=False)
   parser.add_argument('--skip-kernel-test', action='store_true',
                       help='If specified, the kernel starting command is not tested.\n'
                            'This can be useful for starting kernels that do not expose\n'
@@ -62,107 +44,117 @@ def install_kernel(kernel_name, ssh_host, **kwargs):
   skip_kernel_test = kwargs.get('skip_kernel_test', False)
   no_remote_files = kwargs.get('no_remote_files', False)
 
-  clients = []
   try:
-    # Connect via jump server(s) if specified
-    for srvr in jump_server:
-      client = ParamikoClient()
-      client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-      logger.debug('Connecting to jump server %s@%s:%i', client.username, client.host, client.port)
-      client.connect_override(srvr, ssh_key, clients[-1] if len(clients) > 0 else None)
-      clients.append(client)
-    ssh_client = ParamikoClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    logger.debug('Connecting to remote server %s@%s:%i', ssh_client.username, ssh_client.host, ssh_client.port)
-    ssh_client.connect_override(ssh_host, ssh_key, clients[-1] if len(clients) > 0 else None)
-    clients.append(ssh_client)
+    with ParamikoClient().connect_override(ssh_host, ssh_key, jump_server) as ssh_client:
+      logger.info('Connection to remote server successfull!')
 
-    logger.info('Connection to remote server successfull!')
+      chan = ssh_client.get_transport().open_session()
+      chan.get_pty()
+      cmds = []
+      if pre_command is not None:
+        cmds.append(pre_command)
+      if not skip_kernel_test:
+        cmds.append('%s --help-all' % kernel_cmd)
 
-    chan = ssh_client.get_transport().open_session()
-    chan.get_pty()
-    cmds = []
-    if pre_command is not None:
-      cmds.append(pre_command)
-    if not skip_kernel_test:
-      cmds.append('%s --help-all' % kernel_cmd)
+      cmd = ' && '.join(cmds)
 
-    cmd = ' && '.join(cmds)
+      logger.debug('Running cmd %s', cmd)
+      chan.exec_command(cmd)
+      result = chan.recv_exit_status()
 
-    logger.debug('Running cmd %s', cmd)
-    chan.exec_command(cmd)
-    result = chan.recv_exit_status()
-
-    output = ''
-    data = chan.recv(4096)
-    while data:
-      output += data.decode('utf-8')
-      logger.debug("REMOTE >>> " + data.decode('utf-8'))
+      output = ''
       data = chan.recv(4096)
+      while data:
+        output += data.decode('utf-8')
+        logger.debug("REMOTE >>> " + data.decode('utf-8'))
+        data = chan.recv(4096)
 
-    if result != 0:
-      logger.error('CMD %s returned a non-zero exit status on remote server.\n\n%s', cmd, output)
-      return 1
-    elif not skip_kernel_test:
-      for cmd in CMD_ARGS.keys():
-        if '\n' + cmd not in output:
-          logger.error('Help message does not specify required argument %s', cmd)
+      if result != 0:
+        logger.error('CMD %s returned a non-zero exit status on remote server.\n\n%s', cmd, output)
+        return 1
+      elif not skip_kernel_test:
+        for cmd in CMD_ARGS.keys():
+          if '\n' + cmd not in output:
+            logger.error('Help message does not specify required argument %s', cmd)
+            return 1
+
+      if dry_run:
+        logger.info('Test passed, returning without writing kernel specs.')
+        return 0
+
+      if kwargs.get('synchronize', False):
+        try:
+          synchronizer = ParamikoSync(ssh_client, **{k: v for k, v in kwargs.items() if k in
+                                                     ('local_folder=', 'remote_folder', 'recursive', 'bi_directional')})
+
+          with synchronizer.connect(skip_check=True):
+            synchronizer.check_remote_sync_folder()
+        except:
+          logger.error('Error setting up synchronization on the remote server!', exc_info=True)
           return 1
 
-    if dry_run:
-      logger.info('Test passed, returning without writing kernel specs.')
+      logger.info('Command successful, writing kernel_spec file')
+      name_spec = dict(
+        user=ssh_client.username,
+        host=ssh_client.host,
+        port=ssh_client.port
+      )
+      kernel_name = kernel_name % name_spec
+      safe_name = ''.join(c if c.isalnum() or c in ('.', '-', '_') else '-' for c in kernel_name).rstrip()
+
+      kernel_dir = os.path.join(jupyter_data_dir(), 'kernels', safe_name)
+
+      if os.path.isdir(kernel_dir):
+        logger.error('Kernel directory %s already exists. Choose another name or delete the directory', kernel_dir)
+        return 1
+
+      # Build-up command args to start a kernel
+      kernel_args = [
+        sys.executable,
+        '-m', 'remote_kernel',
+        '-t', ssh_host
+      ]
+      if jump_server is not None:
+        for j in jump_server:
+          kernel_args += ['-J', j]
+      if ssh_key is not None:
+        kernel_args += ['-i', ssh_key]
+      if pre_command is not None:
+        kernel_args += ['-c', pre_command]
+      if kernel_cmd != 'python -m ipykernel':
+        kernel_args += ['-k', kernel_cmd]
+      if no_remote_files:
+        kernel_args += ['--no-remote-files']
+      kernel_args += ['-f', '{connection_file}']
+
+      # Synchronization config
+      if kwargs.get('synchronize', False):
+        kernel_args += ['-s']
+        if not kwargs.get('recursive', True):
+          kernel_args += ['--no-recursive']
+        if kwargs.get('bi_directional', False):
+          kernel_args += ['--bi-directional']
+        if kwargs.get('local_folder', 'remote_kernel_sync') != 'remote_kernel_sync':
+          kernel_args += ['--local-folder', kwargs['local_folder']]
+        if kwargs.get('remote_folder', 'remote_kernel_sync') != 'remote_kernel_sync':
+          kernel_args += ['--remote-folder', kwargs['remote_folder']]
+
+      kernel_spec = dict(
+        argv=kernel_args,
+        language='python',
+        display_name=kernel_name
+      )
+
+      os.makedirs(kernel_dir)
+      with open(os.path.join(kernel_dir, 'kernel.json'), mode='w') as kernel_fs:
+        json.dump(kernel_spec, kernel_fs, indent=2)
+
+      resource_dir = get_resource_dir()
+      for fname in ('logo-32x32.png', 'logo-64x64.png'):
+        shutil.copy(os.path.join(resource_dir, fname), os.path.join(kernel_dir, fname))
+
+      logger.info('Kernel specification installed in %s', kernel_dir)
       return 0
-
-    logger.info('Command successful, writing kernel_spec file')
-    name_spec = dict(
-      user=ssh_client.username,
-      host=ssh_client.host,
-      port=ssh_client.port
-    )
-    kernel_name = kernel_name % name_spec
-    safe_name = ''.join(c if c.isalnum() or c in ('.', '-', '_') else '-' for c in kernel_name).rstrip()
-
-    kernel_dir = os.path.join(jupyter_data_dir(), 'kernels', safe_name)
-
-    if os.path.isdir(kernel_dir):
-      logger.error('Kernel directory %s already exists. Choose another name or delete the directory', kernel_dir)
-      return 1
-
-    # Build-up command args to start a kernel
-    kernel_args = [
-      sys.executable,
-      '-m', 'remote_kernel',
-      '-t', ssh_host
-    ]
-    if jump_server is not None:
-      for j in jump_server:
-        kernel_args += ['-J', j]
-    if ssh_key is not None:
-      kernel_args += ['-i', ssh_key]
-    if pre_command is not None:
-      kernel_args += ['-c', '%s && python -m ipykernel' % pre_command]
-    if no_remote_files:
-      kernel_args += ['--no-remote-files']
-    kernel_args += ['-f', '{connection_file}']
-
-    kernel_spec = dict(
-      argv=kernel_args,
-      language='python',
-      display_name=kernel_name
-    )
-
-    os.makedirs(kernel_dir)
-    with open(os.path.join(kernel_dir, 'kernel.json'), mode='w') as kernel_fs:
-      json.dump(kernel_spec, kernel_fs, indent=2)
-
-    resource_dir = get_resource_dir()
-    for fname in ('logo-32x32.png', 'logo-64x64.png'):
-      shutil.copy(os.path.join(resource_dir, fname), os.path.join(kernel_dir, fname))
-
-    logger.info('Kernel specification installed in %s', kernel_dir)
-    return 0
-
-  finally:
-    clients.reverse()
-    for client in clients:
-      client.close()
+  except:
+    logger.error('Error installing kernel specs!', exc_info=True)
+    return 2

--- a/remote_kernel/sync.py
+++ b/remote_kernel/sync.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import time
@@ -13,27 +14,76 @@ class ParamikoSync(object):
                bi_directional=False):
     self.logger = logging.getLogger('remote_kernel.sync')
 
-    self.recursive = recursive
-    self.bi_directional = bi_directional
-    self.logger.debug('Starting SFTP client')
-    self.sftp_client = SFTP.from_transport(ssh_client.get_transport())
+    self.ssh_client = ssh_client
+    self.sftp_client = None
 
     self.local_folder = os.path.abspath(local_folder)
     self.logger.debug('Normalized local path to %s', self.local_folder)
-    self.remote_folder = self.sftp_client.normalize(remote_folder)
-    self.logger.debug('Normalized remote path to %s', self.remote_folder)
+    self.remote_folder = remote_folder
 
-    self._check_sync_folders()
+    # Directionality and extent of synchronization
+    self.recursive = recursive
+    self.bi_directional = bi_directional
 
-    self.excluded_files = {}
+    # Local and remote sync folders are only checked when a connection is first made.
+    self._is_folder_checked = False
 
+    # Files that should be excluded during synchronization
+    self.excluded_files = {'.remote_kernel_sync'}  # config file to allow separate subfolders
+
+    # Epoch time of last synchronization
     self._last_sync = 0
 
+  def __del__(self):
+    self.logger.debug('Finalizing ParamikoSync instance')
+    self.close()  # Ensure the connection is closed
+    self.ssh_client = None
+
   def __enter__(self):
+    self.connect()
     return self
 
   def __exit__(self, exc_type, exc_val, exc_tb):
     self.close()
+
+  def connect(self):
+    if self.sftp_client is None:
+      self.logger.debug('Starting SFTP client')
+      self.sftp_client = SFTP.from_transport(self.ssh_client.get_transport())
+
+      if not self._is_folder_checked:
+        self._check_sync_folders()
+    return self
+
+  def close(self):
+    if self.sftp_client:
+      self.logger.debug('Closing SFTP Client')
+      self.sftp_client.close()
+      self.sftp_client = None
+
+  def set_subfolder(self, kernel_name):
+    local_config = os.path.join(self.local_folder, '.remote_kernel_sync')
+    if os.path.isfile(local_config):
+      with open(local_config) as conf_fs:
+        config = json.load(conf_fs)
+    else:
+      config = {}
+
+    kernel_config = config.get(kernel_name, None)
+    if kernel_config is None:
+      with self.connect():  # This connection ensures local and remote root folders are created
+        remote_folders = self.get_remote_dirs()
+        i = 1
+        while str(i) in remote_folders:
+          i += 1
+        self.remote_folder = self._unix_join(self.remote_folder, str(i))
+        self.logger.info('Creating synchronization sub-folder %s', self.remote_folder)
+        self.sftp_client.mkdir(self.remote_folder)
+      config[kernel_name] = {'remote_kernel_id': str(i)}
+      with open(local_config, mode='w') as out_fs:
+        json.dump(config, out_fs)
+    else:
+      self.remote_folder = self._unix_join(self.remote_folder, kernel_config['remote_kernel_id'])
 
   def _check_sync_folders(self):
     if self.sftp_client is None:
@@ -44,6 +94,9 @@ class ParamikoSync(object):
       self.logger.info('Creating local sync directory %s', self.local_folder)
       os.makedirs(self.local_folder)
 
+    self.remote_folder = self.sftp_client.normalize(self.remote_folder)
+    self.logger.debug('Normalized remote path to %s', self.remote_folder)
+
     remote_dirname = os.path.dirname(self.remote_folder)
     remote_basename = os.path.basename(self.remote_folder)
     remote_dirs = {entry.filename: entry for entry in self.sftp_client.listdir_attr(remote_dirname)}
@@ -53,8 +106,17 @@ class ParamikoSync(object):
       self.logger.info('Creating remote sync directory %s', self.remote_folder)
       self.sftp_client.mkdir(self.remote_folder)
 
+    self._is_folder_checked = True
+
   def get_chdir_cmd(self):
     return 'cd "%s"' % self.remote_folder
+
+  def get_remote_dirs(self, folder='.'):
+    return [
+      entry.filename
+      for entry in self.sftp_client.listdir_attr(self._unix_join(self.remote_folder, folder))
+      if self._isdir(entry)
+    ]
 
   def sync(self):
     if self.sftp_client is None:
@@ -67,7 +129,7 @@ class ParamikoSync(object):
     self._last_sync = time.time()
 
   def _sync_local_folder(self, folder='.'):
-    self.logger.debug('Synchronizing local folder %s to remote folder %s',
+    self.logger.info('Synchronizing local folder %s to remote folder %s',
                       self._unix_join(self.local_folder, folder), self.remote_folder)
     folder_stack = [folder]
 
@@ -89,9 +151,10 @@ class ParamikoSync(object):
               self.sftp_client.mkdir(self._unix_join(self.remote_folder, entry_path))
 
             folder_stack.append(entry_path)
-        elif entry in self.excluded_files or entry_stat.st_mtime < self._last_sync:  # Not changed since last sync, skip
-          continue
-        else:
+        elif entry in self.excluded_files or entry_stat.st_mtime < self._last_sync:
+          continue  # Excluded or unchanged since last sync, skip
+        else:  # This file should be synced!
+          # Compare to the local version if it exists
           remote_file = remote_entries.get(entry, None)
           remote_mtime = 0
           if remote_file is not None:
@@ -99,11 +162,12 @@ class ParamikoSync(object):
 
           if entry_stat.st_mtime > remote_mtime:
             dest_file = self._unix_join(self.remote_folder, entry_path)
+            self.logger.info('Pushing file %s to the remote', entry_path)
             self.sftp_client.put(os.path.join(self.local_folder, entry_path), dest_file)
             self.sftp_client.utime(dest_file, (entry_stat.st_atime, entry_stat.st_mtime))
 
   def _sync_remote_folder(self, folder='.'):
-    self.logger.debug('Synchronizing remote folder %s to local folder %s',
+    self.logger.info('Synchronizing remote folder %s to local folder %s',
                       self._unix_join(self.remote_folder, folder), self.local_folder)
     folder_stack = [folder]
 
@@ -116,9 +180,10 @@ class ParamikoSync(object):
         if self._isdir(entry):
           if self.recursive:
             folder_stack.append(entry_path)
-        elif entry.st_mtime < self._last_sync:  # Not changed since last sync, skip
-          continue
-        else:
+        elif entry in self.excluded_files or entry.st_mtime < self._last_sync:
+          continue  # Excluded or unchanged since last sync, skip
+        else:  # This file should be synced!
+          # Compare to the local version if it exists
           local_file = os.path.join(self.local_folder, entry_path)
           local_mtime = 0
           if os.path.isfile(local_file):
@@ -131,6 +196,7 @@ class ParamikoSync(object):
               os.makedirs(dest_dir)
 
             # Get the file
+            self.logger.info('Getting file %s from the remote', entry_path)
             self.sftp_client.get(self._unix_join(self.remote_folder, entry_path), local_file)
 
             # Set the local file's modified time to the modified time on the server
@@ -143,9 +209,3 @@ class ParamikoSync(object):
   @staticmethod
   def _unix_join(*path_parts):
     return '/'.join(path_parts)
-
-  def close(self):
-    if self.sftp_client:
-      self.logger.debug('Closing SFTP Client')
-      self.sftp_client.close()
-      self.sftp_client = None

--- a/remote_kernel/sync.py
+++ b/remote_kernel/sync.py
@@ -1,0 +1,139 @@
+import logging
+import os
+import time
+
+from paramiko import SFTP
+
+
+class ParamikoSync(object):
+  def __init__(self, ssh_client,
+               local_folder='./remote_kernel_sync',
+               remote_folder='./remote_kernel_sync',
+               recursive=True,
+               bi_directional=False):
+    self.logger = logging.getLogger('remote_kernel.sync')
+
+    self.recursive = recursive
+    self.bi_directional = bi_directional
+    self.sftp_server = SFTP.from_transport(ssh_client.get_transport())
+
+    self.local_folder = os.path.abspath(local_folder)
+    self.remote_folder = self.sftp_server.normalize(remote_folder)
+
+    self._check_sync_folders()
+
+    self._last_sync = 0
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    self.close()
+
+  def _check_sync_folders(self):
+    if self.sftp_server is None:
+      self.logger.warning('This ParamikoSync instance has been closed')
+      return
+
+    if not os.path.isdir(self.local_folder):
+      os.makedirs(self.local_folder)
+
+    remote_dirname = os.path.dirname(self.remote_folder)
+    remote_basename = os.path.basename(self.remote_folder)
+    remote_dirs = {entry.filename: entry for entry in self.sftp_server.listdir_attr(remote_dirname)}
+
+    # Ensure the folder structure in the sync folder is copied
+    if remote_basename not in remote_dirs.keys() or not self._isdir(remote_dirs[remote_basename]):
+      self.sftp_server.mkdir(self.remote_folder)
+
+  def get_chdir_cmd(self):
+    return 'cd "%s"' % self.remote_folder
+
+  def sync(self):
+    if self.sftp_server is None:
+      self.logger.warning('This ParamikoSync instance has been closed')
+      return
+
+    self._sync_remote_folder('.')
+    if self.bi_directional:
+      self._sync_local_folder('.')
+    self._last_sync = time.time()
+
+  def _sync_local_folder(self, folder):
+    folder_stack = [folder]
+
+    while len(folder_stack) > 0:
+      fldr = folder_stack.pop()
+
+      entries = os.listdir(os.path.join(self.local_folder, fldr))
+      remote_entries = {entry.filename: entry for entry in
+        self.sftp_server.listdir_attr(self._unix_join(self.remote_folder, fldr))}
+
+      for entry in entries:
+        entry_path = self._unix_join(fldr, entry)
+        entry_stat = os.stat(os.path.join(self.local_folder, entry_path))
+
+        if self._isdir(entry_stat):
+          if self.recursive:
+            # Ensure the folder structure in the sync folder is copied
+            if entry not in remote_entries.keys() or not self._isdir(remote_entries[entry]):
+              self.sftp_server.mkdir(self._unix_join(self.remote_folder, entry_path))
+
+            folder_stack.append(entry_path)
+        elif entry_stat.st_mtime < self._last_sync:  # Not changed since last sync, skip
+          continue
+        else:
+          remote_file = remote_entries.get(entry, None)
+          remote_mtime = 0
+          if remote_file is not None:
+            remote_mtime = remote_file.st_mtime
+
+          if entry_stat.st_mtime > remote_mtime:
+            dest_file = self._unix_join(self.remote_folder, entry_path)
+            self.sftp_server.put(os.path.join(self.local_folder, entry_path), dest_file)
+            self.sftp_server.utime(dest_file, (entry_stat.st_atime, entry_stat.st_mtime))
+
+  def _sync_remote_folder(self, folder):
+    folder_stack = [folder]
+
+    while len(folder_stack) > 0:
+      fldr = folder_stack.pop()
+      entries = self.sftp_server.listdir_attr(self._unix_join(self.remote_folder, fldr))
+
+      for entry in entries:
+        entry_path = self._unix_join(fldr, entry.filename)
+        if self._isdir(entry):
+          if self.recursive:
+            folder_stack.append(entry_path)
+        elif entry.st_mtime < self._last_sync:  # Not changed since last sync, skip
+          continue
+        else:
+          local_file = os.path.join(self.local_folder, entry_path)
+          local_mtime = 0
+          if os.path.isfile(local_file):
+            local_mtime = os.stat(local_file).st_mtime
+
+          if entry.st_mtime > local_mtime:
+            # Ensure the destination directory exists
+            dest_dir = os.path.join(self.local_folder, fldr)
+            if not os.path.isdir(dest_dir):
+              os.makedirs(dest_dir)
+
+            # Get the file
+            self.sftp_server.get(self._unix_join(self.remote_folder, entry_path), local_file)
+
+            # Set the local file's modified time to the modified time on the server
+            os.utime(local_file, (entry.st_atime, entry.st_mtime))
+
+  @staticmethod
+  def _isdir(attr):
+    return (attr.st_mode & 0o40000) == 0o40000
+
+  @staticmethod
+  def _unix_join(*path_parts):
+    return '/'.join(path_parts)
+
+  def close(self):
+    if self.sftp_server:
+      self.sftp_server.close()
+      self.sftp_server = None


### PR DESCRIPTION
Add `sync.py`, which allows easy synchronization between the remote server running the kernel and the local machine starting the kernel.

- Creates a remote folder for synchronization. For each local folder, a new subfolder is created in this sync folder, and it's details are stored in a small config file in the local folder. This way multiple local folders can be synced without conflicts, but doesn't require separate kernel definitions per local folder.
- Supports recursive (default True) and bi-directional (default only remote -> local) synchronization

In addition, several changes have been made to the code to simplify the use:

- Enable the use of `remote_kernel` ssh clients in a `with` block to ensure correct disposal of instances.
- Simplify the opening of an ssh channel through (one or more) jump hosts by making the `connect_override` function recursive for hosts in the `jump_host` argument.
- Remove differences in command line interface for kernel start and kernel installation. Add code to ensure older-style kernel definitions are updated to the new format.
- Use absolute imports in `__main__.py`, allowing the use of this script even when starting the script directly from the source code.